### PR TITLE
Coverage reporter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Download coverage
         uses: actions/download-artifact@v2
         with:
-          name: code-coverage-report
+          name: code-coverage-summary
           path: ./
 
       - name: Create Badge


### PR DESCRIPTION
Implements a GitHub actions coverage reporter without any third-party